### PR TITLE
Use standard GNU- and BSD-style options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ A simple web server will be hosted at
 
 To host at a different port, set the PORT environment variable (For example, host on port 8080).  
 
-	hostr -p=8080
+```sh
+hostr --port=8080  # or `-p 8080`
+```
 
 
 Watch Changes
@@ -47,7 +49,9 @@ Watch Changes
 
 To disable watching (debugging only)
 
-	hostr -w=off
+```sh
+hostr --watch=off  # or `-w off`
+```
 
 To ignore files create a `.hostrignore` file in the current working directory using minimatch notation
 
@@ -78,11 +82,15 @@ Then run hostr and when file changes are detected your browser will refresh.
 
 LiveReload port can be changed (default: 35729), to use port 32021
 
-	hostr -r=32021
+```sh
+hostr --livereload-port=32021  # or `-r 32021`
+```
 
 To disable LiveReload
 
-	hostr -l=off
+```sh
+hostr --livereload=off  # or `-l off`
+```
 
 
 
@@ -91,7 +99,9 @@ Cache
 
 To change cache expiration time (seconds, default: 60)
 
-	host -c=5
+```sh
+host --cache-expiration=5  # or `-c 5`
+```
 
 
 
@@ -100,8 +110,10 @@ Quiet Mode
 
 To run quietly use 
 
-	hostr -q
-	
+```sh
+hostr --quiet  # or `-q`
+```
+
 And output will be suppressed
 
 


### PR DESCRIPTION
I’ve never seen the `-p=8080` notation – it puzzled me a bit. I guess a more mainstream format will be more developer-friendly :)
