### PR TITLE
Auto-inject the LiveReload script

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -76,12 +76,13 @@ var debug = require('./debug')(process.env.QUIET === 'true');
 
 // LiveReload
 var reloader;
+var rport = process.env.LIVERELOAD_PORT || argr.get('livereload-port');
+rport = isNaN(rport) ? 35729 : +rport;
+
 if(argr.get('livereload') && argr.get('livereload')[0] !== 'off') {
   var tinylr = require('tiny-lr');
-  var rport = process.env.LIVERELOAD_PORT || argr.get('livereload-port');
 
   reloader = tinylr();
-  rport = isNaN(rport) ? 35729 : +rport;
   reloader.listen(rport, function() {
     debug.log('LiveReload '+rport);
   });
@@ -90,9 +91,14 @@ if(argr.get('livereload') && argr.get('livereload')[0] !== 'off') {
 // Serve
 var statics;
 var port = process.env.PORT || argr.get('port');
+var inject = require('inject-lr-script');
 var server = require('./server')({
   port: port
 })
+  .use(function(req, res, next) {
+    inject(res, {port: rport});
+    next();
+  })
   .use(statics = require('./routes/statics')({
     cacheExpiration: argr.get('cache-expiration')
   }))

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "argr": "~1.1.7",
     "colors": "^1.1.0",
+    "inject-lr-script": "^1.0.1",
     "lodash": "~2.4.1",
     "minimatch": "^2.0.8",
     "mocha": "~2.0.1",


### PR DESCRIPTION
Fixes #3.

Caution! Definitely not ready to merge!

I must admit I’m new to writing servers. I’ve tried out what you see in the commit, but it feels like walking around blindly and crashing into things.

[Your code in `lib/routes`](https://github.com/henrytseng/hostr/blob/1cfbe99f12fb0bdc74c7e124a9d96b752a0129e7/lib/routes/notfound.js) looks completely different than that of [_inject-lr-script_](https://github.com/mattdesl/inject-lr-script/blob/b9ec627aa82936fc876a417eea2aac74158bf98a/index.js). Maybe there two aren’t compatible after all? Even though you both use `require('http')` under the hood.
